### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Test Nginx TorBlocker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/nginx-torblocker/security/code-scanning/1](https://github.com/RumenDamyanov/nginx-torblocker/security/code-scanning/1)

To fix the issue, we should add an explicit `permissions` block that limits the GITHUB_TOKEN used in this workflow. Because the workflow only checks out code and performs build/test tasks, it is sufficient to grant only `contents: read` permission. This should be added at the workflow root level (top of the YAML file, below the `name:` and above or below the `on:` block), ensuring all jobs/steps in the workflow use these reduced permissions unless overridden. No other permissions are necessary for the described steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
